### PR TITLE
LS-31: Fix ELB health check URL

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'spain@livesafemobile.com'
 license          'All rights reserved'
 description      'Installs/Configures lvsf-opsworks-cookbook'
 long_description 'Installs/Configures lvsf-opsworks-cookbook'
-version          '1.1.2'
+version          '1.1.3'
 
 depends 'ohai'
 depends 'apt'

--- a/templates/default/nginx/sites-available/ingress-routing.erb
+++ b/templates/default/nginx/sites-available/ingress-routing.erb
@@ -8,7 +8,16 @@ map $domain $proxy_proto {
 server {
     listen 80 default_server;
     server_name "";
-    return 444;
+
+    # ELB Health check URL
+    location = /elb-health-check {
+        add_header Content-Type text/plain;
+        return 200 "Success";
+    }
+
+    location = / {
+        return 444;
+    }
 }
 
 server {

--- a/test/integration/ingress-router-setup/serverspec/localhost/localhost_spec.rb
+++ b/test/integration/ingress-router-setup/serverspec/localhost/localhost_spec.rb
@@ -18,6 +18,7 @@ end
 
 {
   'dashboard.hexxie.com/elb-health-check' => /^Success$/,
+  'crazy-town-domain.hexxie.com/elb-health-check' => /^Success$/,
   'dashboard.hexxie.com' => /^You have reached: php$/,
   'services.hexxie.com' => /^You have reached: php$/,
   'services.hexxie.com/2/service/name' => /^You have reached: php$/,

--- a/wercker.yml
+++ b/wercker.yml
@@ -44,4 +44,4 @@ build:
     after-steps:
         - dignifiedquire/flowdock-notify:
             token: $FLOWDOCK_TOKEN
-            from_address: werckerbot@company.com
+            from_address: spain+wercker@livesafemobile.com


### PR DESCRIPTION
* Respond to health check in default_server config

##### Testing

1. Bring up locally
1. see that `/elb-health-check` responds with Success no matter what hostname is used